### PR TITLE
implement "tank" command

### DIFF
--- a/cmd/fish/tank.go
+++ b/cmd/fish/tank.go
@@ -1,17 +1,34 @@
 package main
 
 import (
-	"errors"
+	"fmt"
 
+	"github.com/fishworks/fish"
 	"github.com/spf13/cobra"
 )
+
+type tank map[string]string
+
+func (t tank) fill() {
+	home := fish.Home(fish.HomePath)
+	t["FISH_HOME"] = home.String()
+	t["FISH_BARREL"] = home.Barrel()
+	t["FISH_RIGS"] = home.Rigs()
+	t["FISH_DEFAULT_RIG"] = home.DefaultRig()
+}
 
 func newTankCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "tank",
 		Short: "display information about fish's environment",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return errors.New("`fish tank` is not implemented")
+			t := tank{}
+			t.fill()
+			for k, v := range t {
+				fmt.Printf("export %s=%q\n", k, v)
+			}
+			fmt.Print("# Run this command to configure your shell:\n# eval $(fish tank)\n")
+			return nil
 		},
 	}
 	return cmd


### PR DESCRIPTION
Similar to `minikube docker-env`:

```
$ fish tank
export FISH_BARREL="/usr/local/Fish/Barrel"
export FISH_RIGS="/usr/local/Fish/Rigs"
export FISH_DEFAULT_RIG="/usr/local/Fish/Rigs/github.com/fishworks/fish-food"
export FISH_HOME="/usr/local/Fish"
# Run this command to configure your shell:
# eval $(fish tank)
```
```
$ eval $(fish tank)
```
```
$ env | grep ^FISH_
FISH_DEFAULT_RIG=/usr/local/Fish/Rigs/github.com/fishworks/fish-food
FISH_BARREL=/usr/local/Fish/Barrel
FISH_RIGS=/usr/local/Fish/Rigs
FISH_HOME=/usr/local/Fish
```

Fixes #17 (maybe??!)